### PR TITLE
Fix ordering of variable names when using LASSO

### DIFF
--- a/PLSDA_main.m
+++ b/PLSDA_main.m
@@ -67,6 +67,7 @@ end
 [~,idx]=min(minMSE);
 varNames = varNames_old(any(lasso_feat(:,idx),2));
 [~,ia,~] = intersect(varNames_old,varNames);
+varNames = varNames_old(ia); %reorders varNames to match order in X
 X = X(:,ia); %subset X to only contain LASSO-selected features
 X_pre_z = X_pre_z(:,ia); %subset X_pre_z to only LASSO-selected features
 end


### PR DESCRIPTION
When using LASSO, variable names do not always reflect the correct data if their order differs in the varNames as compared to varNames_old. This corrects that so that the names will match with their correct data.